### PR TITLE
fix: set explicit PackageId to preserve NuGet package names

### DIFF
--- a/source/Directory.Build.props
+++ b/source/Directory.Build.props
@@ -10,7 +10,7 @@
 
   <!-- Package metadata for NuGet publishing -->
   <PropertyGroup Label="Package Metadata">
-    <Version>1.0.0-beta.11</Version>
+    <Version>1.0.0-beta.12</Version>
     <Authors>Steven T. Cramer</Authors>
     <RepositoryUrl>https://github.com/TimeWarpEngineering/timewarp-jaribu</RepositoryUrl>
     <RepositoryType>git</RepositoryType>

--- a/source/timewarp-jaribu-testing-platform/build/TimeWarp.Jaribu.TestingPlatform.props
+++ b/source/timewarp-jaribu-testing-platform/build/TimeWarp.Jaribu.TestingPlatform.props
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- build/timewarp-jaribu-testing-platform.props -->
+<!-- build/TimeWarp.Jaribu.TestingPlatform.props -->
 <Project>
 
   <PropertyGroup>

--- a/source/timewarp-jaribu-testing-platform/timewarp-jaribu-testing-platform.csproj
+++ b/source/timewarp-jaribu-testing-platform/timewarp-jaribu-testing-platform.csproj
@@ -1,5 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
+    <PackageId>TimeWarp.Jaribu.TestingPlatform</PackageId>
     <Description>Microsoft.Testing.Platform adapter for TimeWarp.Jaribu test framework</Description>
     <!-- This is a library, not a test project -->
     <IsTestProject>false</IsTestProject>

--- a/source/timewarp-jaribu/timewarp-jaribu.csproj
+++ b/source/timewarp-jaribu/timewarp-jaribu.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <PackageId>TimeWarp.Jaribu</PackageId>
     <Description>Lightweight testing helpers for single-file C# programs and scripts. Jaribu (Swahili: test/trial) provides TestRunner pattern and assertion helpers for executable .cs files.</Description>
     <PackageTags>testing;test-runner;single-file;csharp-scripts;test-helpers;assertions</PackageTags>
     <!-- Suppress analyzers that don't apply to test frameworks -->

--- a/tests/timewarp-jaribu-mtp-validation/timewarp-jaribu-mtp-validation.csproj
+++ b/tests/timewarp-jaribu-mtp-validation/timewarp-jaribu-mtp-validation.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <!-- Import the TestingPlatform props (auto-imported when using NuGet package) -->
-  <Import Project="../../source/timewarp-jaribu-testing-platform/build/timewarp-jaribu-testing-platform.props" />
+  <Import Project="../../source/timewarp-jaribu-testing-platform/build/TimeWarp.Jaribu.TestingPlatform.props" />
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>

--- a/tests/timewarp-jaribu/multi-file-runners/mtp-runner/timewarp-jaribu-tests-mtp.csproj
+++ b/tests/timewarp-jaribu/multi-file-runners/mtp-runner/timewarp-jaribu-tests-mtp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <!-- Import M.T.P. props for dotnet test / IDE integration -->
-  <Import Project="../../../../source/timewarp-jaribu-testing-platform/build/timewarp-jaribu-testing-platform.props" />
+  <Import Project="../../../../source/timewarp-jaribu-testing-platform/build/TimeWarp.Jaribu.TestingPlatform.props" />
 
   <PropertyGroup>
     <!-- Define JARIBU_MULTI so test files don't self-execute -->

--- a/tools/dev-cli/endpoints/workflow-command.cs
+++ b/tools/dev-cli/endpoints/workflow-command.cs
@@ -165,14 +165,28 @@ internal sealed class WorkflowCommand : ICommand<Unit>
       string artifactsDir = Path.Combine(repoRoot, "artifacts", "packages");
       Directory.CreateDirectory(artifactsDir);
 
-        exitCode = await Shell.Builder("dotnet")
-          .WithArguments("pack", Path.Combine(repoRoot, "source", "timewarp-jaribu", "timewarp-jaribu.csproj"), "-c", "Release", "-o", artifactsDir)
-          .WithWorkingDirectory(repoRoot)
-          .RunAsync();
+      // Pack main package
+      Terminal.WriteLine("  Packing TimeWarp.Jaribu...");
+      exitCode = await Shell.Builder("dotnet")
+        .WithArguments("pack", Path.Combine(repoRoot, "source", "timewarp-jaribu", "timewarp-jaribu.csproj"), "-c", "Release", "-o", artifactsDir)
+        .WithWorkingDirectory(repoRoot)
+        .RunAsync();
 
       if (exitCode != 0)
       {
-        throw new InvalidOperationException("Pack failed!");
+        throw new InvalidOperationException("Pack TimeWarp.Jaribu failed!");
+      }
+
+      // Pack MTP adapter package
+      Terminal.WriteLine("  Packing TimeWarp.Jaribu.TestingPlatform...");
+      exitCode = await Shell.Builder("dotnet")
+        .WithArguments("pack", Path.Combine(repoRoot, "source", "timewarp-jaribu-testing-platform", "timewarp-jaribu-testing-platform.csproj"), "-c", "Release", "-o", artifactsDir)
+        .WithWorkingDirectory(repoRoot)
+        .RunAsync();
+
+      if (exitCode != 0)
+      {
+        throw new InvalidOperationException("Pack TimeWarp.Jaribu.TestingPlatform failed!");
       }
 
       Terminal.WriteLine("\n✓ Release Pipeline completed successfully");


### PR DESCRIPTION
## Summary

Fix package naming issue caused by kebab-case refactoring. The project files were renamed to `timewarp-jaribu.csproj` and `timewarp-jaribu-testing-platform.csproj`, which caused MSBuild to derive the package names from the filenames instead of the original `TimeWarp.Jaribu` and `TimeWarp.Jaribu.TestingPlatform`.

## Changes

1. **PackageId Fix** - Add explicit `<PackageId>` to each project file:
   - `TimeWarp.Jaribu` in `timewarp-jaribu.csproj`
   - `TimeWarp.Jaribu.TestingPlatform` in `timewarp-jaribu-testing-platform.csproj`

2. **Release Workflow** - Explicitly pack both NuGet packages:
   - `TimeWarp.Jaribu` (main package)
   - `TimeWarp.Jaribu.TestingPlatform` (MTP adapter)

3. **Version:** Bumped to 1.0.0-beta.12

## Background

The `TimeWarp.Jaribu.TestingPlatform` package was always intended (from Epic #010) to provide Microsoft.Testing.Platform integration for `dotnet test` and IDE Test Explorer support. It was never published before because the old workflow only pushed the main package. The new workflow correctly publishes both packages.

**Full Changelog**: https://github.com/TimeWarpEngineering/timewarp-jaribu/compare/v1.0.0-beta.11...dev